### PR TITLE
Update Dockerfile to multi-stage with official images

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,5 +1,5 @@
 0.0.0.0:5000
-root /var/www/html/dist
+root /var/www/html
 gzip
 log stdout
 errors stdout

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,31 @@
-FROM zzrot/alpine-caddy
+FROM node:10-alpine as builder
 
+ENV NODE_ENV development
+
+WORKDIR /usr/src/app
+
+# Install build dependencies
+RUN apk add --no-cache make gcc g++ python git && \
+  # Install grunt and bower
+	npm i -g grunt-cli@1.2.0 bower
+
+# Install npm dependencies
+COPY ./public/package.json ./public/package-lock.* /usr/src/app/
+RUN npm i
+
+# Install bower dependencies
+COPY ./public/bower.json /usr/src/app/
+RUN bower install --allow-root
+
+# Build assets
+COPY ./public /usr/src/app/
+RUN grunt
+
+FROM abiosoft/caddy:no-stats
+
+# Copy Caddyfile
 COPY Caddyfile /etc/Caddyfile
-COPY ./public /var/www/html
+# Copy assets from builder
+COPY --from=builder /usr/src/app/dist /var/www/html
 
 WORKDIR /var/www/html
-# Instala npm y dependencias para compilar
-# Instala grunt y bower
-# Instala las dependencias de npm y bower
-# Ejecuta grunt
-# Elimina la cache de npm, npm y archivos temporales
-RUN apk add --no-cache --virtual build-dependencies make gcc g++ python nodejs-npm && \
-	npm i -g grunt-cli@1.2.0 bower && \
-	npm install && \
-	bower install --allow-root && \
-	grunt && \
-	npm cache clean --force && \
-  	apk del build-dependencies && \
-  	rm -rf ~/.node-gyp /tmp/*


### PR DESCRIPTION
Se agrego [multi-stage](https://docs.docker.com/develop/develop-images/multistage-build/) para construir la imagen docker y de esa forma disminuir el tamaño final de la imagen.

Ademas se migro a las imágenes oficiales de [node](https://hub.docker.com/_/node) y [caddy](https://hub.docker.com/r/abiosoft/caddy).